### PR TITLE
[Issue3] - Running trident-server/usr/sbin/tsetup --force-db-dest…

### DIFF
--- a/lib/system.go
+++ b/lib/system.go
@@ -387,7 +387,7 @@ func System_db_test_setup() (err error) {
 
 	/* Find the Application specific test data */
 	fn := System_findfile("dbschemas/", "APP_test_data.psql")
-	if fn == "" {
+	if fn != "" {
 		/* Found it, execute it */
 		err = DB.executeFile(fn)
 	}


### PR DESCRIPTION
Fixes issue3 - Running trident-server/usr/sbin/tsetup --force-db-destroy setup_test_db results in an error:

APP_test_data.psql can't be found. This is because the logic is swapped on looking for the file and
acting on if its found or not.