### PR TITLE
[Issue 2] - The path being used for the 404 test now is protected by a login

### DIFF
--- a/ui/root_test.go
+++ b/ui/root_test.go
@@ -18,7 +18,7 @@ func TestUI_Main_Misc(t *testing.T) {
 			http.StatusOK, []string{}, []string{}},
 
 		/* Missing pages check */
-		urltest.URLTest_404("/404"),
+		urltest.URLTest_404("/gfx/404"),
 	}
 
 	/* Our Root */


### PR DESCRIPTION
[Issue 2] - The path being used for the 404 test now is protected by a login. There is an unsecured path in /gfx for serving images for the front page - for now I'll just try to serve a non existent page from there to get the 404 failure (instead of a 401)