### PR TITLE
[issue 11] - Fix issue with submenu inconsistency in Group->Files and Group->Mailing List

### DIFF
--- a/share/templates/ml/list_with_user.tmpl
+++ b/share/templates/ml/list_with_user.tmpl
@@ -64,4 +64,10 @@
 	</tr>
 	{{ end }}</table>
 
+	{{ if $.Admin }}
+	<p>
+		<a class="fakebutton" href="/group/{{ $group }}/ml/new/">New Mailing List</a>
+	</p>
+	{{ end }}
+
 {{template "inc/footer.tmpl" .}}

--- a/share/templates/ml/members.tmpl
+++ b/share/templates/ml/members.tmpl
@@ -1,7 +1,13 @@
 {{template "inc/header.tmpl" .}}
+	<p>
+		{{ if .Admin }}
+		<a class="fakebutton" href="settings">Settings</a>
+		{{ end }}
+		<a class="fakebutton" href="pgp">PGP Key</a>
+	</p>
 
 	<p>
-		Following is a list of the member of the <b>{{ .GroupName }}</b> group's <b>{{ .ML.ListName }}</b> Mailing List.
+		Following is a list of the members of the <b>{{ .GroupName }}</b> group's <b>{{ .ML.ListName }}</b> Mailing List.
 	</p>
 
 {{template "inc/search.tmpl" .}}

--- a/ui/file.go
+++ b/ui/file.go
@@ -447,14 +447,19 @@ func H_file(cui PfUI) {
 		sub = "?s=" + sub
 	}
 
-	switch sub {
-	case "?s=add_file":
-		h_file_add_file(cui)
-	case "?s=add_dir":
-		h_file_add_dir(cui)
-	case "?s=details":
-		h_file_details(cui)
-	default:
-		h_file_list(cui)
+	ok, _ := cui.CheckPerms("H_file", PERM_USER)
+	if ok {
+		switch sub {
+		case "?s=add_file":
+			h_file_add_file(cui)
+		case "?s=add_dir":
+			h_file_add_dir(cui)
+		case "?s=details":
+			h_file_details(cui)
+		default:
+			h_file_list(cui)
+		}
+	} else {
+		H_NoAccess(cui)
 	}
 }

--- a/ui/file.go
+++ b/ui/file.go
@@ -433,23 +433,11 @@ func file_edit_form(cui PfUI, path string) (err error) {
 func H_file(cui PfUI) {
 	/* URL of the page */
 	cui.SetSubPath("/" + cui.GetPathString())
-
 	for _, p := range cui.GetPath() {
 		cui.AddCrumb(p, p, "")
 	}
 
 	sub := cui.GetArg("s")
-
-	menu := NewPfUIMenu([]PfUIMentry{
-		{"", "", PERM_USER, h_file_list, nil},
-		{"?s=add_file", "Add File", PERM_USER, h_file_add_file, nil},
-		{"?s=add_dir", "Add Directory", PERM_USER, h_file_add_dir, nil},
-		{"?s=list", "List", PERM_USER, h_file_list, nil},
-		{"?s=details", "Details", PERM_USER | PERM_HIDDEN | PERM_NOCRUMB, h_file_details, nil},
-		/* TODO History & editing/revising files is not yet implemented */
-		/* TODO {"?s=history", "History", PERM_USER, h_file_history}, */
-		/* TODO {"?s=edit", "Edit", PERM_USER | PERM_HIDDEN, h_file_edit}, */
-	})
 
 	if sub == "list" {
 		sub = ""
@@ -459,5 +447,14 @@ func H_file(cui PfUI) {
 		sub = "?s=" + sub
 	}
 
-	cui.MenuPath(menu, &[]string{sub})
+	switch sub {
+	case "?s=add_file":
+		h_file_add_file(cui)
+	case "?s=add_dir":
+		h_file_add_dir(cui)
+	case "?s=details":
+		h_file_details(cui)
+	default:
+		h_file_list(cui)
+	}
 }

--- a/ui/ml.go
+++ b/ui/ml.go
@@ -125,7 +125,6 @@ func h_ml_list(cui PfUI) {
 	var username string
 	username = ""
 	template := "ml/list.tmpl"
-	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 	grp := cui.SelectedGroup()
 
 	if cui.HasSelectedUser() {
@@ -157,21 +156,13 @@ func h_ml_list(cui PfUI) {
 	/* Output the page */
 	type Page struct {
 		*PfPage
-		PageSize    int
-		LastPage    int
 		Username  string
 		GroupName string
 		MLs       []pf.PfML
 		Admin     bool
 	}
 
-	menu := NewPfUIMenu([]PfUIMentry{
-		{"new/", "New Mailing List", PERM_GROUP_ADMIN, h_ml_new, nil},
-	})
-
-	cui.SetPageMenu(&menu)
-
-	p := Page{cui.Page_def(), pageSize, 0, username, grp.GetGroupName(), mls, admin}
+	p := Page{cui.Page_def(), username, grp.GetGroupName(), mls, admin}
 	cui.Page_show(template, p)
 }
 
@@ -372,7 +363,6 @@ func h_ml_unsubscribe(cui PfUI) {
 func h_ml(cui PfUI) {
 	path := cui.GetPath()
 	if len(path) == 0 || path[0] == "" {
-		cui.SetPageMenu(nil)
 		h_ml_list(cui)
 		return
 	}
@@ -405,13 +395,16 @@ func h_ml(cui PfUI) {
 
 	cui.SetPath(path[1:])
 
-	menu := NewPfUIMenu([]PfUIMentry{
-		{"", "", PERM_GROUP_MEMBER, h_ml_members, nil},
-		{"settings", "Settings", PERM_GROUP_ADMIN, h_ml_settings, nil},
-		{"subscribe", "Subscribe", PERM_GROUP_MEMBER, h_ml_subscribe, nil},
-		{"unsubscribe", "Unsubscribe", PERM_GROUP_MEMBER, h_ml_unsubscribe, nil},
-		{"pgp", "PGP Key", PERM_GROUP_MEMBER, h_ml_pgp, nil},
-	})
-
-	cui.UIMenu(menu)
+	switch path[1] {
+	case "settings":
+		h_ml_settings(cui)
+	case "pgp":
+		h_ml_pgp(cui)
+	case "subscribe":
+		h_ml_subscribe(cui)
+	case "unsubscribe":
+		h_ml_unsubscribe(cui)
+	default:
+		h_ml_members(cui)
+	}
 }

--- a/ui/ml.go
+++ b/ui/ml.go
@@ -397,14 +397,39 @@ func h_ml(cui PfUI) {
 
 	switch path[1] {
 	case "settings":
-		h_ml_settings(cui)
+		ok, _ := cui.CheckPerms("h_ml", PERM_GROUP_ADMIN)
+		if ok {
+			h_ml_settings(cui)
+		} else {
+			H_NoAccess(cui)
+		}
 	case "pgp":
-		h_ml_pgp(cui)
+		ok, _ := cui.CheckPerms("h_ml", PERM_GROUP_MEMBER)
+		if ok {
+			h_ml_pgp(cui)
+		} else {
+			H_NoAccess(cui)
+		}
 	case "subscribe":
-		h_ml_subscribe(cui)
+		ok, _ := cui.CheckPerms("h_ml", PERM_GROUP_MEMBER)
+		if ok {
+			h_ml_subscribe(cui)
+		} else {
+			H_NoAccess(cui)
+		}
 	case "unsubscribe":
-		h_ml_unsubscribe(cui)
+		ok, _ := cui.CheckPerms("h_ml", PERM_GROUP_MEMBER)
+		if ok {
+			h_ml_unsubscribe(cui)
+		} else {
+			H_NoAccess(cui)
+		}
 	default:
-		h_ml_members(cui)
+		ok, _ := cui.CheckPerms("h_ml", PERM_GROUP_MEMBER)
+		if ok {
+			h_ml_members(cui)
+		} else {
+			H_NoAccess(cui)
+		}
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -825,6 +825,17 @@ func (cui *PfUIS) Page_def() (p *PfPage) {
 
 	/* Generate Sub Menu from pagemenu */
 	menu := mainmenu.ToLinkCol(cui, 0)
+
+	/* If we are quite deep in a path (ie. /group/<groupname>/file/a/b/c/d) the page menu depth wasn't
+	   calculated properly. Calculating it here */
+	splitFn := func(c rune) bool {
+		return c == '/'
+	}
+	path := strings.FieldsFunc(cui.GetFullPath(), splitFn)
+	pathlen := len(path)
+	if pathlen > 2 {
+		cui.pagemenudepth = pathlen - 2
+	}
 	submenu := cui.pagemenu.ToLinkCol(cui, cui.pagemenudepth)
 
 	p = &PfPage{


### PR DESCRIPTION
The issue was originally started that the sub menu for "…Files" and "Mailing List" was not consistent
with the rest of the items in "Group". I fixed this by:
 - modifying the templates to move the functions that were in the submenu for these specific screens to be part of the screen instead
 - modify the screens to not hide their default submenus
 - modify the logic for how depth is calculated, which is used for relative pathing on the submenu items href="" definition. (it was only working for a depth of one - anything deeper than /group/<groupname>/file was failing)