### PR TITLE
[Issue 20] - Responsiveness issues paging through Group->Audit Log screen

### DIFF
--- a/lib/db.go
+++ b/lib/db.go
@@ -101,7 +101,7 @@ func (db *PfDB) Init(verbosity bool) {
 	db.sql = nil
 
 	/* Current portal_schema_version -- must match schema.sql! */
-	db.version = 21
+	db.version = 22
 
 	/* No configured App DB */
 	db.appversion = -1

--- a/share/dbschemas/DB_21.psql
+++ b/share/dbschemas/DB_21.psql
@@ -1,0 +1,12 @@
+-- Starting Version 21
+BEGIN;
+
+CREATE INDEX audit_history_entered_tg on audit_history(trustgroup, entered desc);
+
+-- Set the db version properly.
+--Update Version.
+UPDATE schema_metadata
+   SET value = 22
+ WHERE value = 21
+   AND key = 'portal_schema_version';
+COMMIT;


### PR DESCRIPTION
[Issue 20] - Responsiveness issues paging through Group->Audit Log screen

The query to retreive the audit history was slow because the index on query that pulled the audit log page for the trust group didn't capture the ORDER BY DESC on `entered` and the WHERE clause on `trustgroup`.

Added the following index:
CREATE INDEX audit_history_entered_2 ON audit_history(trustgroup, entered desc);

Makes the query go from 850ms to 0.96 ms (all times measured on my local box)