### PR TITLE
[Pitchfork/Issue17] - Adds first page and last page buttons to pager templates.

### DIFF
--- a/lib/template.go
+++ b/lib/template.go
@@ -48,6 +48,14 @@ func Template_Get() *template.Template {
 	return g_tmp
 }
 
+/* Pager related helper function - calculate the offest for the "last" page */
+func Template_Pager_LastPage(total int, pageSize int) int {
+	/* This math is a bit odd because we depend on the math truncaction. Imagine we're going to the last
+	   page of a group of 14 entries, and each page is 4 entries. 14/4 is 3 (truncated). 4*3 gives an offset of 12,
+	   the last page of entries 12-14 */
+	return (total/pageSize) * pageSize
+}
+
 /* Template Functions - used from inside the templates */
 func tmp_pager_less_ok(cur int) bool {
 	return cur >= PAGER_PERPAGE

--- a/share/templates/inc/pager.tmpl
+++ b/share/templates/inc/pager.tmpl
@@ -1,35 +1,68 @@
 <p>
+	<fieldset><table><tr><td>
 	{{ if pager_less_ok .PagerOffset }}
-	{{ csrf_form $.UI "" }}
-		<fieldset>
-			<ul>
-				<li>
-					{{ if .Search }}
-						<input type="hidden" name="search" value="{{ .Search }}" />
-					{{ end }}
-					<input type="hidden" name="offset" value="{{ pager_less .PagerOffset }}" />
-					<input id="button" type="submit" name="button" value="Back" />
-				</li>
-			</ul>
-		</fieldset>
-	</form>
+		{{ csrf_form $.UI "" }}
+			{{ if .Search }}
+				<input type="hidden" name="search" value="{{ .Search }}" />
+			{{ end }}
+			<input type="hidden" name="offset" value="{{ 0 }}" />
+			<input id="button" type="submit" name="button" value="<< First" />
+		</form>
+	{{ else }}
+		<form class="styled_form">
+			<input type="submit" name="button" value="<< First" disabled />
+		</form>
+	{{ end }}
+	</td>
 
+	<td>
+	{{ if pager_less_ok .PagerOffset }}
+		{{ csrf_form $.UI "" }}
+			{{ if .Search }}
+				<input type="hidden" name="search" value="{{ .Search }}" />
+			{{ end }}
+			<input type="hidden" name="offset" value="{{ pager_less .PagerOffset }}" />
+			<input id="button" type="submit" name="button" value="< Back" />
+		</form>
+	{{ else }}
+		<form class="styled_form">
+			<input type="submit" name="button" value="< Back" disabled />
+		</form>
 	{{ end }}
+	</td>
+
+	<td>
 	{{ if pager_more_ok .PagerOffset .PagerTotal }}
-	{{ csrf_form $.UI "" }}
-		<fieldset>
-			<ul>
-				<li>
-					{{ if .Search }}
-						<input type="hidden" name="search" value="{{ .Search }}" />
-					{{ end }}
-					<input type="hidden" name="offset" value="{{ pager_more .PagerOffset .PagerTotal }}" />
-					<input id="button" type="submit" name="button" value="Forward" />
-				</li>
-			</ul>
-		</fieldset>
-	</form>
+		{{ csrf_form $.UI "" }}
+			{{ if .Search }}
+				<input type="hidden" name="search" value="{{ .Search }}" />
+			{{ end }}
+			<input type="hidden" name="offset" value="{{ pager_more .PagerOffset .PagerTotal }}" />
+			<input id="button" type="submit" name="button" value="Forward >" />
+		</form>
+	{{ else }}
+		<form class="styled_form">
+			<input type="submit" name="button" value="Forward >" disabled />
+		</form>
 	{{ end }}
+	</td>
+
+	<td>
+	{{ if pager_more_ok .PagerOffset .PagerTotal }}
+		{{ csrf_form $.UI "" }}
+			{{ if .Search }}
+				<input type="hidden" name="search" value="{{ .Search }}" />
+			{{ end }}
+			<input type="hidden" name="offset" value="{{ .LastPage }}" />
+			<input id="button" type="submit" name="button" value="Last >>" />
+		</form>
+
+	{{ else }}
+		<form class="styled_form">
+			<input type="submit" name="button" value="Last >>" disabled />
+		</form>
+	{{ end }}
+	</td></tr></table></fieldset>
 </p>
 <p>
 	Offset: {{ .PagerOffset }}, Total: {{ .PagerTotal }}

--- a/share/templates/inc/pager.tmpl
+++ b/share/templates/inc/pager.tmpl
@@ -7,15 +7,9 @@
 	<table><tr><td>
 	{{ if pager_less_ok .PagerOffset }}
 		<button type="submit" name="offset" value="{{ 0 }}">&lt;&lt; First</button> 
-	{{ else }}
-		<button disabled>&lt;&lt; First</button>
-	{{ end }}
-	</td>
-
-	<td>
-	{{ if pager_less_ok .PagerOffset }}
 		<button type="submit" name="offset" value="{{ pager_less .PagerOffset }}">&lt; Back</button>
 	{{ else }}
+		<button disabled>&lt;&lt; First</button>
 		<button disabled>&lt; Back</button>
 	{{ end }}
 	</td>
@@ -23,17 +17,12 @@
 	<td>
 	{{ if pager_more_ok .PagerOffset .PagerTotal }}
 		<button type="submit" name="offset" value="{{ pager_more .PagerOffset .PagerTotal }}">Forward &gt;</button>
-	{{ else }}
-		<button disabled>Forward &gt;</button>
-	{{ end }}
-	</td>
-
-	<td>
-	{{ if pager_more_ok .PagerOffset .PagerTotal }}
 		<button type="submit" name="offset" value="{{ .LastPage }}">Last &gt;&gt;</button>
 	{{ else }}
+		<button disabled>Forward &gt;</button>
 		<button disabled>Last &gt;&gt;</button>
 	{{ end }}
+	</td>
 	</td></tr></table></form>
 </p>
 <p>

--- a/share/templates/inc/pager.tmpl
+++ b/share/templates/inc/pager.tmpl
@@ -1,68 +1,40 @@
 <p>
-	<fieldset><table><tr><td>
+	{{ csrf_form $.UI "" }}
+	{{ if .Search }}
+		<input type="hidden" name="search" value="{{ .Search }}" />
+	{{ end }}
+
+	<table><tr><td>
 	{{ if pager_less_ok .PagerOffset }}
-		{{ csrf_form $.UI "" }}
-			{{ if .Search }}
-				<input type="hidden" name="search" value="{{ .Search }}" />
-			{{ end }}
-			<input type="hidden" name="offset" value="{{ 0 }}" />
-			<input id="button" type="submit" name="button" value="<< First" />
-		</form>
+		<button type="submit" name="offset" value="{{ 0 }}">&lt;&lt; First</button> 
 	{{ else }}
-		<form class="styled_form">
-			<input type="submit" name="button" value="<< First" disabled />
-		</form>
+		<button disabled>&lt;&lt; First</button>
 	{{ end }}
 	</td>
 
 	<td>
 	{{ if pager_less_ok .PagerOffset }}
-		{{ csrf_form $.UI "" }}
-			{{ if .Search }}
-				<input type="hidden" name="search" value="{{ .Search }}" />
-			{{ end }}
-			<input type="hidden" name="offset" value="{{ pager_less .PagerOffset }}" />
-			<input id="button" type="submit" name="button" value="< Back" />
-		</form>
+		<button type="submit" name="offset" value="{{ pager_less .PagerOffset }}">&lt; Back</button>
 	{{ else }}
-		<form class="styled_form">
-			<input type="submit" name="button" value="< Back" disabled />
-		</form>
+		<button disabled>&lt; Back</button>
 	{{ end }}
 	</td>
 
 	<td>
 	{{ if pager_more_ok .PagerOffset .PagerTotal }}
-		{{ csrf_form $.UI "" }}
-			{{ if .Search }}
-				<input type="hidden" name="search" value="{{ .Search }}" />
-			{{ end }}
-			<input type="hidden" name="offset" value="{{ pager_more .PagerOffset .PagerTotal }}" />
-			<input id="button" type="submit" name="button" value="Forward >" />
-		</form>
+		<button type="submit" name="offset" value="{{ pager_more .PagerOffset .PagerTotal }}">Forward &gt;</button>
 	{{ else }}
-		<form class="styled_form">
-			<input type="submit" name="button" value="Forward >" disabled />
-		</form>
+		<button disabled>Forward &gt;</button>
 	{{ end }}
 	</td>
 
 	<td>
 	{{ if pager_more_ok .PagerOffset .PagerTotal }}
-		{{ csrf_form $.UI "" }}
-			{{ if .Search }}
-				<input type="hidden" name="search" value="{{ .Search }}" />
-			{{ end }}
-			<input type="hidden" name="offset" value="{{ .LastPage }}" />
-			<input id="button" type="submit" name="button" value="Last >>" />
-		</form>
-
+		<button type="submit" name="offset" value="{{ .LastPage }}">Last &gt;&gt;</button>
 	{{ else }}
-		<form class="styled_form">
-			<input type="submit" name="button" value="Last >>" disabled />
-		</form>
+		<button disabled>Last &gt;&gt;</button>
 	{{ end }}
-	</td></tr></table></fieldset>
+	</td></tr></table></form>
 </p>
 <p>
 	Offset: {{ .PagerOffset }}, Total: {{ .PagerTotal }}

--- a/share/webroot/css/form.css
+++ b/share/webroot/css/form.css
@@ -57,7 +57,7 @@
 	float			: left;
 }
 
-.styled_form input, .styled_form .fakebutton
+.styled_form input, .fakebutton
 {
 	min-width		: 42em;
 	min-height		: 2em;
@@ -89,13 +89,13 @@
 	padding-right		: 0px;
 }
 
-.styled_form input[type=submit], .fakebutton
+.styled_form input[type=submit], .styled_form button, .fakebutton 
 {
 	font-size		: 100%;
 }
 
 /* form element visual styles */
-.styled_form input, .styled_form textarea, .fakebutton
+.styled_form input, .styled_form textarea, .styled_form button, .fakebutton
 {
 	border			: 1px solid #aaa;
 	box-shadow		: 0px 0px 3px #ccc, 0 10px 15px #eee inset;
@@ -246,7 +246,7 @@ form.styled_form li span.error
 	          user-select	: none;
 }
 
-.styled_form input[type=submit], .fakebutton
+.styled_form input[type=submit], .styled_form button, .fakebutton
 {
 	border-radius		: 3px;
 	-webkit-border-radius	: 3px;
@@ -265,7 +265,7 @@ form.styled_form li span.error
 	text-shadow		: 0 -1px 0 #396715;
 }
 
-.styled_form input[type=submit], .fakebutton
+.styled_form input[type=submit], .styled_form button, .fakebutton
 {
 	background-color	: #68b12f;
 	background		: -webkit-gradient(linear, left top, left bottom, from(#68b12f), to(#50911e));
@@ -289,7 +289,7 @@ input:disabled, input:read-only
 	-o-box-shadow		: none;
 }
 
-.styled_form input[type=submit]:disabled, a.fakebutton.disabled, a.fakebutton.disabled:hover
+.styled_form input[type=submit]:disabled, .styled_form button:disabled, a.fakebutton.disabled, a.fakebutton.disabled:hover
 {
 	background-color	: #eeeeee;
 	background		: -webkit-gradient(linear, left top, left bottom, from(#aaaaaa), to(#911e0d));
@@ -347,7 +347,7 @@ a.fakebutton, a.fakebutton a:visited, a.fakebutton:hover
 	border-bottom		: none;
 }
 
-input[type=submit]:active, .fakebutton:active
+input[type=submit]:active, .styled_form button:active, .fakebutton:active
 {
 	border			: 1px solid #20911e;
 	box-shadow		: 0 0 10px 5px #356b0b inset;

--- a/share/webroot/css/form.css
+++ b/share/webroot/css/form.css
@@ -57,7 +57,7 @@
 	float			: left;
 }
 
-.styled_form input, .fakebutton
+.styled_form input, .styled_form .fakebutton
 {
 	min-width		: 42em;
 	min-height		: 2em;

--- a/ui/file.go
+++ b/ui/file.go
@@ -14,6 +14,7 @@ func h_file_history(cui PfUI) {
 
 	total := 0
 	offset := 0
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	offset_v, err := cui.FormValue("offset")
 	if err == nil && offset_v != "" {
@@ -35,13 +36,15 @@ func h_file_history(cui PfUI) {
 	/* Output the page */
 	type Page struct {
 		*PfPage
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
 		Revs        []pf.PfFile
 	}
 
-	p := Page{cui.Page_def(), offset, total, "", revs}
+	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", revs}
 	cui.Page_show("file/history.tmpl", p)
 }
 
@@ -64,6 +67,7 @@ func h_file_list_dir(cui PfUI) {
 
 	total := 0
 	offset := 0
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	offset_v, err := cui.FormValue("offset")
 	if err == nil && offset_v != "" {
@@ -87,13 +91,15 @@ func h_file_list_dir(cui PfUI) {
 	/* Output the page */
 	type Page struct {
 		*PfPage
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
 		Paths       []pf.PfFile
 	}
 
-	p := Page{cui.Page_def(), offset, total, "", paths}
+	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", paths}
 	cui.Page_show("file/list.tmpl", p)
 }
 

--- a/ui/file.go
+++ b/ui/file.go
@@ -44,7 +44,7 @@ func h_file_history(cui PfUI) {
 		Revs        []pf.PfFile
 	}
 
-	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", revs}
+	p := Page{cui.Page_def(), pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, "", revs}
 	cui.Page_show("file/history.tmpl", p)
 }
 
@@ -99,7 +99,7 @@ func h_file_list_dir(cui PfUI) {
 		Paths       []pf.PfFile
 	}
 
-	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", paths}
+	p := Page{cui.Page_def(), pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, "", paths}
 	cui.Page_show("file/list.tmpl", p)
 }
 

--- a/ui/group.go
+++ b/ui/group.go
@@ -135,7 +135,7 @@ func h_group_member(cui PfUI) {
 	}
 
 	isadmin := cui.IAmGroupAdmin()
-	p := Page{cui.Page_def(), grp, members, pageSize, total/pageSize, offset, total, search, isadmin}
+	p := Page{cui.Page_def(), grp, members, pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, search, isadmin}
 	cui.Page_show("group/members.tmpl", p)
 }
 

--- a/ui/group.go
+++ b/ui/group.go
@@ -85,6 +85,7 @@ func h_group_log(cui PfUI) {
 
 func h_group_member(cui PfUI) {
 	path := cui.GetPath()
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	if len(path) != 0 && path[0] != "" {
 		H_group_member_profile(cui)
@@ -125,6 +126,8 @@ func h_group_member(cui PfUI) {
 		*PfPage
 		Group       pf.PfGroup
 		Members     []pf.PfGroupMember
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
@@ -132,8 +135,7 @@ func h_group_member(cui PfUI) {
 	}
 
 	isadmin := cui.IAmGroupAdmin()
-
-	p := Page{cui.Page_def(), grp, members, offset, total, search, isadmin}
+	p := Page{cui.Page_def(), grp, members, pageSize, total/pageSize, offset, total, search, isadmin}
 	cui.Page_show("group/members.tmpl", p)
 }
 

--- a/ui/ml.go
+++ b/ui/ml.go
@@ -229,7 +229,8 @@ func h_ml_members(cui PfUI) {
 	if cui.IsSysAdmin() || cui.IAmGroupAdmin() {
 		admin = true
 	}
-	p := Page{cui.Page_def(), sel_grp.GetGroupName(), admin, sel_ml, members, pageSize, total/pageSize, offset, total, search, admin}
+
+	p := Page{cui.Page_def(), sel_grp.GetGroupName(), admin, sel_ml, members, pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, search, admin}
 	cui.Page_show("ml/members.tmpl", p)
 }
 

--- a/ui/ml.go
+++ b/ui/ml.go
@@ -125,7 +125,7 @@ func h_ml_list(cui PfUI) {
 	var username string
 	username = ""
 	template := "ml/list.tmpl"
-
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 	grp := cui.SelectedGroup()
 
 	if cui.HasSelectedUser() {
@@ -157,6 +157,8 @@ func h_ml_list(cui PfUI) {
 	/* Output the page */
 	type Page struct {
 		*PfPage
+		PageSize    int
+		LastPage    int
 		Username  string
 		GroupName string
 		MLs       []pf.PfML
@@ -169,12 +171,13 @@ func h_ml_list(cui PfUI) {
 
 	cui.SetPageMenu(&menu)
 
-	p := Page{cui.Page_def(), username, grp.GetGroupName(), mls, admin}
+	p := Page{cui.Page_def(), pageSize, 0, username, grp.GetGroupName(), mls, admin}
 	cui.Page_show(template, p)
 }
 
 func h_ml_members(cui PfUI) {
 	var ml pf.PfML
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	sel_grp := cui.SelectedGroup()
 	sel_ml := cui.SelectedML()
@@ -214,6 +217,8 @@ func h_ml_members(cui PfUI) {
 		GroupAdmin  bool
 		ML          pf.PfML
 		Members     []pf.PfMLUser
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
@@ -224,8 +229,7 @@ func h_ml_members(cui PfUI) {
 	if cui.IsSysAdmin() || cui.IAmGroupAdmin() {
 		admin = true
 	}
-
-	p := Page{cui.Page_def(), sel_grp.GetGroupName(), admin, sel_ml, members, offset, total, search, admin}
+	p := Page{cui.Page_def(), sel_grp.GetGroupName(), admin, sel_ml, members, pageSize, total/pageSize, offset, total, search, admin}
 	cui.Page_show("ml/members.tmpl", p)
 }
 

--- a/ui/system.go
+++ b/ui/system.go
@@ -76,11 +76,7 @@ func h_system_logA(cui PfUI, user_name string, tg_name string) {
 		Search      string
 	}
 
-	/* This math is a bit odd because we depend on the math truncaction. Imagine we're going to the last
-	   page of a group of 14 entries, and each page is 4 entries. 14/4 is 3 (truncated). 4*3 gives an offset of 12,
-	   the last page of entries 12-14 */
-	lastPage := (total/pageSize) * pageSize
-	p := Page{cui.Page_def(), audits, pageSize, lastPage, offset, total, search}
+	p := Page{cui.Page_def(), audits, pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, search}
 	cui.Page_show("system/log.tmpl", p)
 }
 

--- a/ui/system.go
+++ b/ui/system.go
@@ -44,6 +44,7 @@ func h_system_logA(cui PfUI, user_name string, tg_name string) {
 
 	total := 0
 	offset := 0
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	offset_v, err := cui.FormValue("offset")
 	if err == nil && offset_v != "" {
@@ -57,7 +58,7 @@ func h_system_logA(cui PfUI, user_name string, tg_name string) {
 
 	var audits []pf.PfAudit
 	total, _ = pf.System_AuditMax(search, user_name, tg_name)
-	audits, err = pf.System_AuditList(search, user_name, tg_name, offset, 10)
+	audits, err = pf.System_AuditList(search, user_name, tg_name, offset, pageSize)
 	if err != nil {
 		cui.Err(err.Error())
 		return
@@ -67,12 +68,19 @@ func h_system_logA(cui PfUI, user_name string, tg_name string) {
 	type Page struct {
 		*PfPage
 		Audits      []pf.PfAudit
+
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
 	}
 
-	p := Page{cui.Page_def(), audits, offset, total, search}
+	/* This math is a bit odd because we depend on the math truncaction. Imagine we're going to the last
+	   page of a group of 14 entries, and each page is 4 entries. 14/4 is 3 (truncated). 4*3 gives an offset of 12,
+	   the last page of entries 12-14 */
+	lastPage := (total/pageSize) * pageSize
+	p := Page{cui.Page_def(), audits, pageSize, lastPage, offset, total, search}
 	cui.Page_show("system/log.tmpl", p)
 }
 

--- a/ui/user.go
+++ b/ui/user.go
@@ -446,6 +446,7 @@ func h_user_log(cui PfUI) {
 }
 
 func h_user_list(cui PfUI) {
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 	if !cui.IsSysAdmin() {
 		/* Non-SysAdmin can only see their own page */
 		cui.SetRedirect("/user/"+cui.TheUser().GetUserName()+"/", StatusSeeOther)
@@ -478,13 +479,15 @@ func h_user_list(cui PfUI) {
 	type Page struct {
 		*PfPage
 		Users       []pf.PfUser
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
 	}
 
 	cui.SetPageMenu(nil)
-	p := Page{cui.Page_def(), users, offset, total, search}
+	p := Page{cui.Page_def(), users, pageSize, total/pageSize, offset, total, search}
 	cui.Page_show("user/list.tmpl", p)
 }
 

--- a/ui/user.go
+++ b/ui/user.go
@@ -487,7 +487,7 @@ func h_user_list(cui PfUI) {
 	}
 
 	cui.SetPageMenu(nil)
-	p := Page{cui.Page_def(), users, pageSize, total/pageSize, offset, total, search}
+	p := Page{cui.Page_def(), users, pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, search}
 	cui.Page_show("user/list.tmpl", p)
 }
 

--- a/ui/wiki.go
+++ b/ui/wiki.go
@@ -199,7 +199,7 @@ func h_wiki_history(cui PfUI) {
 		Revs        []pf.PfWikiRev
 	}
 
-	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", revs}
+	p := Page{cui.Page_def(), pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, "", revs}
 	cui.Page_show("wiki/history.tmpl", p)
 }
 
@@ -250,7 +250,7 @@ func h_wiki_search(cui PfUI) {
 
 	mopts := pf.Wiki_GetModOpts(cui)
 	opt := popt{search, ""}
-	p := Page{cui.Page_def(), opt, pageSize, total/pageSize, offset, total, mopts.URLroot, res}
+	p := Page{cui.Page_def(), opt, pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, mopts.URLroot, res}
 	cui.Page_show("wiki/search.tmpl", p)
 }
 
@@ -293,7 +293,7 @@ func h_wiki_children(cui PfUI) {
 		Paths       []pf.PfWikiPage
 	}
 
-	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", wikis}
+	p := Page{cui.Page_def(), pageSize, pf.Template_Pager_LastPage(total, pageSize), offset, total, "", wikis}
 	cui.Page_show("wiki/children.tmpl", p)
 }
 

--- a/ui/wiki.go
+++ b/ui/wiki.go
@@ -166,6 +166,7 @@ func h_wiki_history(cui PfUI) {
 	var revs []pf.PfWikiRev
 
 	path := cui.GetSubPath()
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	total := 0
 	offset := 0
@@ -190,13 +191,15 @@ func h_wiki_history(cui PfUI) {
 	/* Output the page */
 	type Page struct {
 		*PfPage
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
 		Revs        []pf.PfWikiRev
 	}
 
-	p := Page{cui.Page_def(), offset, total, "", revs}
+	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", revs}
 	cui.Page_show("wiki/history.tmpl", p)
 }
 
@@ -205,6 +208,7 @@ func h_wiki_search(cui PfUI) {
 
 	total := 0
 	offset := 0
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	search, err := cui.FormValue("q")
 
@@ -236,6 +240,8 @@ func h_wiki_search(cui PfUI) {
 	type Page struct {
 		*PfPage
 		Search      popt
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		PathPrefix  string
@@ -244,7 +250,7 @@ func h_wiki_search(cui PfUI) {
 
 	mopts := pf.Wiki_GetModOpts(cui)
 	opt := popt{search, ""}
-	p := Page{cui.Page_def(), opt, offset, total, mopts.URLroot, res}
+	p := Page{cui.Page_def(), opt, pageSize, total/pageSize, offset, total, mopts.URLroot, res}
 	cui.Page_show("wiki/search.tmpl", p)
 }
 
@@ -252,6 +258,7 @@ func h_wiki_children(cui PfUI) {
 	var wikis []pf.PfWikiPage
 
 	path := cui.GetSubPath()
+	pageSize := pf.PAGER_PERPAGE /* TODO: Eventually I'd like this to come in from a parameter */
 
 	total := 0
 	offset := 0
@@ -278,13 +285,15 @@ func h_wiki_children(cui PfUI) {
 	/* Output the page */
 	type Page struct {
 		*PfPage
+		PageSize    int
+		LastPage    int
 		PagerOffset int
 		PagerTotal  int
 		Search      string
 		Paths       []pf.PfWikiPage
 	}
 
-	p := Page{cui.Page_def(), offset, total, "", wikis}
+	p := Page{cui.Page_def(), pageSize, total/pageSize, offset, total, "", wikis}
 	cui.Page_show("wiki/children.tmpl", p)
 }
 


### PR DESCRIPTION
Needs the corresponding Trident PR for issue17 checked in too,

Adds first page and last page buttons to pager templates. Also IMHO improves the look by putting all the buttons in a line

<Also puts in place a bit of change to allow for my next step, which is to add a drop down to let you choose how many entries to put on the page vs only 10. Also I will make all the buttons submit on the same form on the pager.tmpl in my next change, I'll push a change to this same commit and remove this comment from the PR when its done..>